### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "clang++-7 src/main.cpp -o night"

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ print answer;
 And that's it!
 
 Right now, I'm working on some more support for strings, and fixing some bugs with them.
+
+[![Run on Repl.it](https://repl.it/badge/github/DynamicSquid/Night)](https://repl.it/github/DynamicSquid/Night)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).